### PR TITLE
feat:正誤アイコンの表示&だし分け&もう一度遊ぶボタン

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -75,8 +75,6 @@
         </div>
 
         <div id="result">
-            <p id="judged"></p>
-
             <div class="img_sign" >
                 <img id="correct-img" src="" alt="">
                 <div id="result-sign"></div>

--- a/html/index.html
+++ b/html/index.html
@@ -77,26 +77,9 @@
         <div id="result">
             <p id="judged"></p>
 
-            <div class="img_sign">
+            <div class="img_sign" >
                 <img id="correct-img" src="" alt="">
-
-                <!-- 正解 -->
-                <div class="sign_correct">
-                    <svg class="correct_sign" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
-                        <circle class="path circle" fill="none" stroke="#fff" stroke-width="12" stroke-miterlimit="10" cx="65.1" cy="65.1" r="62.1"/>
-                        <polyline class="path check" fill="none" stroke="#fff" stroke-width="12" stroke-linecap="round" stroke-miterlimit="10" points="100.2,40.2 51.5,88.8 29.8,67.5 "/>
-                    </svg>
-                </div>
-
-                <!-- 不正解 -->
-                <div class="sign_uncorrect">
-                    <svg class="uncorrect_sign" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
-                        <circle class="path circle" fill="none" stroke="#fff" stroke-width="12" stroke-miterlimit="10" cx="65.1" cy="65.1" r="62.1"/>
-                        <line class="path line" fill="none" stroke="#fff" stroke-width="12" stroke-linecap="round" stroke-miterlimit="10" x1="34.4" y1="37.9" x2="95.8" y2="92.3"/>
-                        <line class="path line" fill="none" stroke="#fff" stroke-width="12" stroke-linecap="round" stroke-miterlimit="10" x1="95.8" y1="38" x2="34.4" y2="92.2"/>
-                    </svg>
-                </div>
-
+                <div id="result-sign"></div>
             </div>
 
             <!-- 解説を書く領域 -->
@@ -140,7 +123,7 @@
             </div>
 
             <button class="btn_onemore">
-                <input type="button" name="" id="" value="もう一度遊ぶ" onclick="">
+                <input type="button" name="" id="" value="もう一度遊ぶ" onclick="location.reload()">
             </button>
 
         </div>

--- a/js/script.js
+++ b/js/script.js
@@ -8,7 +8,20 @@ var progressValue = 0;
 var progressMaxValue = 0;
 
 const quizzes = quizObject["quizzes"];
+const correctImg = `<div class="sign_correct">
+                    <svg class="correct_sign" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
+                        <circle class="path circle" fill="none" stroke="#fff" stroke-width="12" stroke-miterlimit="10" cx="65.1" cy="65.1" r="62.1"/>
+                        <polyline class="path check" fill="none" stroke="#fff" stroke-width="12" stroke-linecap="round" stroke-miterlimit="10" points="100.2,40.2 51.5,88.8 29.8,67.5 "/>
+                    </svg>
+                    </div>`
 
+const incorrectImg = `<div class="sign_uncorrect">
+                        <svg class="uncorrect_sign" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
+                            <circle class="path circle" fill="none" stroke="#fff" stroke-width="12" stroke-miterlimit="10" cx="65.1" cy="65.1" r="62.1"/>
+                            <line class="path line" fill="none" stroke="#fff" stroke-width="12" stroke-linecap="round" stroke-miterlimit="10" x1="34.4" y1="37.9" x2="95.8" y2="92.3"/>
+                            <line class="path line" fill="none" stroke="#fff" stroke-width="12" stroke-linecap="round" stroke-miterlimit="10" x1="95.8" y1="38" x2="34.4" y2="92.2"/>
+                        </svg>
+                    </div>`
 /**
  * jsonファイルを読み込む
  * @param 
@@ -124,6 +137,8 @@ function displayResult(result) {
 
         document.querySelector("#judged").innerText = "正解";
         document.querySelector("#correct-img").setAttribute('src', quizzes[levelIndex][quizIndex - 1]["question"]["img_path"][selected]);
+        // アイコン表示
+        document.getElementById("result-sign").innerHTML = correctImg;
         doConfetti();
     } else {
         if (quizIndex >= quizzes[levelIndex].length && levelIndex == quizzes.length - 1) {
@@ -134,6 +149,8 @@ function displayResult(result) {
 
         document.querySelector("#judged").innerText = "不正解";
         document.querySelector("#correct-img").setAttribute('src', quizzes[levelIndex][quizIndex - 1]["question"]["img_path"][selected]);
+        // アイコン表示
+        document.getElementById("result-sign").innerHTML = incorrectImg;
     }
 }
 
@@ -238,6 +255,11 @@ function setProgressMaxValue(maxValue) {
 document.getElementById("compare").onmousedown = function displayComparison() {
     let value = selected == 0 ? 1 : 0;
     document.querySelector("#correct-img").setAttribute('src', quizzes[levelIndex][quizIndex - 1]["question"]["img_path"][value]);
+    
+    // アイコン切り替え
+    let signClassName = document.getElementById('result-sign').firstElementChild.className;
+    let sign = signClassName == 'sign_correct' ? incorrectImg : correctImg;
+    document.getElementById("result-sign").innerHTML = sign;
 };
 
 /**
@@ -248,6 +270,11 @@ document.getElementById("compare").onmousedown = function displayComparison() {
 document.getElementById("compare").onmouseup = function undisplayComparison() {
     let value = selected
     document.querySelector("#correct-img").setAttribute('src', quizzes[levelIndex][quizIndex - 1]["question"]["img_path"][value]);
+    
+    // アイコン切り替え
+    let signClassName = document.getElementById('result-sign').firstElementChild.className;
+    let sign = signClassName == 'sign_correct' ? incorrectImg : correctImg;
+    document.getElementById("result-sign").innerHTML = sign;
 }
 
 /**
@@ -299,7 +326,7 @@ function showModal() {
  * @param 
  * @return
  */
-document.querySelector("#close-button").onclick = function closeModal(){
+document.querySelector("#close-button").onclick = function closeModal() {
     var modal = document.querySelector("#modal");
     modal.classList.remove("show-modal");
     document.body.style.overflowY = "visible";

--- a/js/script.js
+++ b/js/script.js
@@ -134,10 +134,7 @@ function displayResult(result) {
         }
         document.querySelector("#quiestion").style.display = "none";
         document.querySelector("#result").style.display = "block";
-
-        document.querySelector("#judged").innerText = "正解";
         document.querySelector("#correct-img").setAttribute('src', quizzes[levelIndex][quizIndex - 1]["question"]["img_path"][selected]);
-        // アイコン表示
         document.getElementById("result-sign").innerHTML = correctImg;
         doConfetti();
     } else {
@@ -146,10 +143,7 @@ function displayResult(result) {
         }
         document.querySelector("#quiestion").style.display = "none";
         document.querySelector("#result").style.display = "block";
-
-        document.querySelector("#judged").innerText = "不正解";
         document.querySelector("#correct-img").setAttribute('src', quizzes[levelIndex][quizIndex - 1]["question"]["img_path"][selected]);
-        // アイコン表示
         document.getElementById("result-sign").innerHTML = incorrectImg;
     }
 }
@@ -253,13 +247,9 @@ function setProgressMaxValue(maxValue) {
  * @return
  */
 document.getElementById("compare").onmousedown = function displayComparison() {
-    let value = selected == 0 ? 1 : 0;
+    let value = 1 - selected;
     document.querySelector("#correct-img").setAttribute('src', quizzes[levelIndex][quizIndex - 1]["question"]["img_path"][value]);
-    
-    // アイコン切り替え
-    let signClassName = document.getElementById('result-sign').firstElementChild.className;
-    let sign = signClassName == 'sign_correct' ? incorrectImg : correctImg;
-    document.getElementById("result-sign").innerHTML = sign;
+    displaySign();
 };
 
 /**
@@ -270,8 +260,15 @@ document.getElementById("compare").onmousedown = function displayComparison() {
 document.getElementById("compare").onmouseup = function undisplayComparison() {
     let value = selected
     document.querySelector("#correct-img").setAttribute('src', quizzes[levelIndex][quizIndex - 1]["question"]["img_path"][value]);
-    
-    // アイコン切り替え
+    displaySign();
+}
+
+/**
+ * compare時の正誤アイコン表示機能
+ * @param
+ * @return
+ */
+function displaySign() {
     let signClassName = document.getElementById('result-sign').firstElementChild.className;
     let sign = signClassName == 'sign_correct' ? incorrectImg : correctImg;
     document.getElementById("result-sign").innerHTML = sign;


### PR DESCRIPTION
## 実装概要
**項目**
- 正誤アイコン表示
- 正誤テキスト削除
- もう一度遊ぶボタン実装

## 実装ファイルパス
- index.html
- script.js

## 見てほしい内容
- クイズの正誤アイコンが正常に出し分けられるか
- 正誤判定機能が正常に動作するか
- もう一度遊ぶボタンでトップに遷移するか
- 正誤比較でアインコンが反転するか

## 確認した内容
- クイズの正誤アイコンが正常に出し分けられるか
- 正誤判定機能が正常に動作するか
- もう一度遊ぶボタンでトップに遷移するか
- 正誤比較でアインコンが反転するか